### PR TITLE
Custom Build Properties: Proof of Concept Implementation

### DIFF
--- a/BeefBuild/src/BuildApp.bf
+++ b/BeefBuild/src/BuildApp.bf
@@ -110,7 +110,7 @@ namespace BeefBuild
 			{
 			    mWorkspace.mName = new String();
 			    Path.GetFileName(mWorkspace.mDir, mWorkspace.mName);
-				LoadProperties();
+				CustomBuildProperties.Load(false);
 			    LoadWorkspace(mVerb);                
 			}
 			else
@@ -308,15 +308,21 @@ namespace BeefBuild
 					int splitIdx = (int)value.IndexOf('=');
 					if (splitIdx != -1)
 					{
-						String propertyKey = new String();
+						String propertyName = new String();
 						StringView propertyKeyView = value.Substring(0, splitIdx);
-						propertyKeyView.ToString(propertyKey);
+						propertyKeyView.ToString(propertyName);
 
 						String propertyValue = new String();
 						StringView propertyValueView = value.Substring(splitIdx + 1, value.Length - splitIdx - 1);
 						propertyValueView.ToString(propertyValue);
 
-						mCustomProperties.Add(propertyKey, propertyValue);
+						if (!CustomBuildProperties.TryAddProperty(propertyName, propertyValue))
+						{
+							delete propertyName;
+							delete propertyValue;
+							return false;
+						}
+
 						return true;
 					}
 				}

--- a/BeefBuild/src/BuildApp.bf
+++ b/BeefBuild/src/BuildApp.bf
@@ -110,6 +110,7 @@ namespace BeefBuild
 			{
 			    mWorkspace.mName = new String();
 			    Path.GetFileName(mWorkspace.mDir, mWorkspace.mName);
+				LoadProperties();
 			    LoadWorkspace(mVerb);                
 			}
 			else
@@ -303,6 +304,21 @@ namespace BeefBuild
 					if (mPackMan.mCleanHashSet.TryAddAlt(value, var entryPtr))
 						*entryPtr = new .(value);
 					return true;
+				case "-property":
+					int splitIdx = (int)value.IndexOf('=');
+					if (splitIdx != -1)
+					{
+						String propertyKey = new String();
+						StringView propertyKeyView = value.Substring(0, splitIdx);
+						propertyKeyView.ToString(propertyKey);
+
+						String propertyValue = new String();
+						StringView propertyValueView = value.Substring(splitIdx + 1, value.Length - splitIdx - 1);
+						propertyValueView.ToString(propertyValue);
+
+						mCustomProperties.Add(propertyKey, propertyValue);
+						return true;
+					}
 				}
 			}
 

--- a/IDE/src/BuildContext.bf
+++ b/IDE/src/BuildContext.bf
@@ -1375,6 +1375,9 @@ namespace IDE
 
 		public bool QueueProjectCompile(Project project, Project hotProject, IDEApp.BuildCompletedCmd completedCompileCmd, List<String> hotFileNames, CompileKind compileKind)
 		{
+			CustomBuildProperties.ResolveProjectProperties(project);
+			defer CustomBuildProperties.UnresolveProjectProperties(project);
+
 			project.mLastDidBuild = false;
 
 			TestManager.ProjectInfo testProjectInfo = null;

--- a/IDE/src/CustomBuildProperties.bf
+++ b/IDE/src/CustomBuildProperties.bf
@@ -198,11 +198,6 @@ namespace IDE
 			}
 		}
 
-		static public void ResolveWorkspaceProperties(Workspace workspace)
-		{
-
-		}
-
 		static public void ResolveProjectProperties(Project project)
 		{
 			if (project == null)

--- a/IDE/src/CustomBuildProperties.bf
+++ b/IDE/src/CustomBuildProperties.bf
@@ -61,11 +61,12 @@ namespace IDE
 			mProjects.Clear();
 		}
 
-		static public void Load()
+		static public void Load(bool clearExistingProperties = true)
 		{
 			const char8* PROPERTIES_STR = "Properties";
 
-			Clear();
+			if (clearExistingProperties)
+				Clear();
 
 			String propertiesFileName = scope String();
 			GetFileName(propertiesFileName);
@@ -85,20 +86,29 @@ namespace IDE
 
 			for (var property in data.Enumerate(PROPERTIES_STR))
 			{
-				String propertyStr = new String();
-				property.ToString(propertyStr);
+				String propertyName = new String();
+				property.ToString(propertyName);
 
-				if (Contains(propertyStr))
+				if (Contains(propertyName))
 				{
-					delete propertyStr;
+					delete propertyName;
 					continue;
 				}
 
 				String propertyValue = new String();
 				data.GetCurString(propertyValue);
 
-				mProperties.Add(propertyStr, propertyValue);
+				TryAddProperty(propertyName, propertyValue);
 			}
+		}
+
+		static public bool TryAddProperty(String propertyName, String propertyValue)
+		{
+			if (Contains(propertyName))
+				return false;
+
+			mProperties.Add(propertyName, propertyValue);
+			return true;
 		}
 
 		static public bool Contains(String property)

--- a/IDE/src/CustomBuildProperties.bf
+++ b/IDE/src/CustomBuildProperties.bf
@@ -1,0 +1,580 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using Beefy.utils;
+
+namespace IDE
+{
+	class CustomBuildProperties
+	{
+		static String[?] BUILT_IN_PROPERTIES = .(
+			"Slash",
+			"Var",
+			"Arguments",
+			"BuildDir",
+			"LinkFlags",
+			"ProjectDir",
+			"ProjectName",
+			"TargetDir",
+			"TargetPath",
+			"WorkingDir",
+			"ProjectName",
+			"VSToolPath",
+			"VSToolPath_x86",
+			"VSToolPath_x64",
+			"EmccPath",
+			"ScriptDir",
+			"Configuration",
+			"Platform",
+			"WorkspaceDir",
+			"BeefPath"
+		);
+
+		static Dictionary<String, String> mProperties = new .() ~ DeleteDictionaryAndKeysAndValues!(_);
+		static Dictionary<Project, Project> mProjects = new .() ~ DeleteDictionaryAndValues!(_); 
+
+		static public void GetFileName(String outResult)
+		{
+			String workspaceDir = scope String();
+
+			if (gApp.mWorkspace.mDir == null)
+				Directory.GetCurrentDirectory(workspaceDir);
+			else
+				workspaceDir = gApp.mWorkspace.mDir;
+
+			outResult.Append(workspaceDir, "/BeefProperties.toml");
+		}
+
+		static public void Clear()
+		{
+			for (var entry in mProperties)
+			{
+				delete entry.key;
+				delete entry.value;
+			}
+
+			for (var entry in mProjects)
+				delete entry.value;
+
+			mProperties.Clear();
+			mProjects.Clear();
+		}
+
+		static public void Load()
+		{
+			const char8* PROPERTIES_STR = "Properties";
+
+			Clear();
+
+			String propertiesFileName = scope String();
+			GetFileName(propertiesFileName);
+
+			if (!File.Exists(propertiesFileName))
+				return;
+
+			StructuredData data = scope StructuredData();
+			if (gApp.StructuredLoad(data, propertiesFileName) case .Err(let err))
+			{
+				gApp.OutputErrorLine("Failed to load properties from: '{0}'", propertiesFileName);
+				return;
+			}
+
+			if (!data.Contains(PROPERTIES_STR))
+				return;
+
+			for (var property in data.Enumerate(PROPERTIES_STR))
+			{
+				String propertyStr = new String();
+				property.ToString(propertyStr);
+
+				if (Contains(propertyStr))
+				{
+					delete propertyStr;
+					continue;
+				}
+
+				String propertyValue = new String();
+				data.GetCurString(propertyValue);
+
+				mProperties.Add(propertyStr, propertyValue);
+			}
+		}
+
+		static public bool Contains(String property)
+		{
+			return mProperties.ContainsKey(property);
+		}
+
+		static public String Get(String property)
+		{
+			if (!Contains(property))
+				return null;
+
+			return mProperties[property];
+		}
+
+		static public void ResolveString(StringView configString, String outResult)
+		{
+			outResult.Set(configString);
+
+			// Find the property to resolve (if any).
+			int i = 0;
+			for (; i < outResult.Length - 2; i++)
+			{
+				if ((outResult[i] == '$') && (outResult[i + 1] == '('))
+				{
+					int parenPos = -1;
+					int openCount = 1;
+					bool inString = false;
+					char8 prevC = 0;
+					for (int checkIdx = i + 2; checkIdx < outResult.Length; checkIdx++)
+					{
+						char8 c = outResult[checkIdx];
+						if (inString)
+						{
+							if (prevC == '\\')
+							{
+								// Slashed char
+								prevC = 0;
+								continue;
+							}
+
+							if (c == '"')
+								inString = false;
+						}
+						else
+						{
+							if (c == '"')
+								inString = true;
+							else if (c == '(')
+								openCount++;
+							else if (c == ')')
+							{
+								openCount--;
+								if (openCount == 0)
+								{
+									parenPos = checkIdx;
+									break;
+								}
+							}
+						}
+
+						prevC = c;
+					}
+
+					if (parenPos != -1)
+						ReplaceBlock:
+							do
+						{
+							// If we reach here, a property has been found.
+							String replaceStr = scope String(outResult, i + 2, parenPos - i - 2);
+
+							// Ignore built-in properties because they are resolved elsewhere.
+							if (BUILT_IN_PROPERTIES.Contains(replaceStr))
+								continue;
+
+							String newString = Get(replaceStr);
+
+							// Resolve custom property value.
+							if (newString != null)
+							{
+								outResult.Remove(i, parenPos - i + 1);
+								outResult.Insert(i, newString);
+								i--;
+							}
+						}
+				}
+			}
+		}
+
+		static public void ResolveWorkspaceProperties(Workspace workspace)
+		{
+
+		}
+
+		static public void ResolveProjectProperties(Project project)
+		{
+			if (project == null)
+				return;
+
+			Project unresolvedProject = new Project();
+			mProjects[project] = unresolvedProject;
+
+			// Deep copy the project so unresolved custom build properties can be restored later,
+			// and resolve any custom build properties in place in the existing project.
+			if (project.mNamespace != null)
+			{
+				unresolvedProject.mNamespace.Set(project.mNamespace);
+				ResolveString(unresolvedProject.mNamespace, project.mNamespace);
+			}
+
+			if (project.mProjectDir != null)
+			{
+				unresolvedProject.mProjectDir.Set(project.mProjectDir);
+				ResolveString(unresolvedProject.mProjectDir, project.mProjectDir);
+			}
+
+			if (project.mProjectName != null)
+			{
+				unresolvedProject.mProjectName.Set(project.mProjectName);
+				ResolveString(unresolvedProject.mProjectName, project.mProjectName);
+			}
+
+			if (project.mProjectPath != null)
+			{
+				unresolvedProject.mProjectPath.Set(project.mProjectPath);
+				ResolveString(unresolvedProject.mProjectPath, project.mProjectPath);
+			}
+
+			if (project.mManagedInfo != null)
+			{
+				unresolvedProject.mManagedInfo = new Project.ManagedInfo();
+				unresolvedProject.mManagedInfo.mVersion.mVersion.Set(project.mManagedInfo.mVersion.mVersion);
+				unresolvedProject.mManagedInfo.mInfo.Set(project.mManagedInfo.mInfo);
+
+				ResolveString(unresolvedProject.mManagedInfo.mVersion.mVersion, project.mManagedInfo.mVersion.mVersion);
+				ResolveString(unresolvedProject.mManagedInfo.mInfo, project.mManagedInfo.mInfo);
+			}
+
+			if (project.mConfigs != null)
+			{
+				DeleteDictionaryAndKeysAndValues!(unresolvedProject.mConfigs);
+				unresolvedProject.mConfigs = new Dictionary<String, Project.Config>();
+
+				for (var config in project.mConfigs)
+				{
+					Project.Config unresolvedConfig = new Project.Config();
+
+					for (var platform in config.value.mPlatforms)
+					{
+						Project.Options unresolvedOptions = platform.value.Duplicate();
+						unresolvedConfig.mPlatforms[new String(platform.key)] = unresolvedOptions;
+
+						ResolveString(unresolvedOptions.mBuildOptions.mTargetDirectory, platform.value.mBuildOptions.mTargetDirectory);
+						ResolveString(unresolvedOptions.mBuildOptions.mTargetName, platform.value.mBuildOptions.mTargetName);
+						ResolveString(unresolvedOptions.mBuildOptions.mOtherLinkFlags, platform.value.mBuildOptions.mOtherLinkFlags);
+
+						for (int32 i = 0; i < unresolvedOptions.mBuildOptions.mLibPaths.Count; i++)
+							ResolveString(unresolvedOptions.mBuildOptions.mLibPaths[i], platform.value.mBuildOptions.mLibPaths[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mBuildOptions.mLinkDependencies.Count; i++)
+							ResolveString(unresolvedOptions.mBuildOptions.mLinkDependencies[i], platform.value.mBuildOptions.mLinkDependencies[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mBuildOptions.mPreBuildCmds.Count; i++)
+							ResolveString(unresolvedOptions.mBuildOptions.mPreBuildCmds[i], platform.value.mBuildOptions.mPreBuildCmds[i]);
+						
+						for (int32 i = 0; i < unresolvedOptions.mBuildOptions.mPostBuildCmds.Count; i++)
+							ResolveString(unresolvedOptions.mBuildOptions.mPostBuildCmds[i], platform.value.mBuildOptions.mPostBuildCmds[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mBuildOptions.mCleanCmds.Count; i++)
+							ResolveString(unresolvedOptions.mBuildOptions.mCleanCmds[i], platform.value.mBuildOptions.mCleanCmds[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mBeefOptions.mPreprocessorMacros.Count; i++)
+							ResolveString(unresolvedOptions.mBeefOptions.mPreprocessorMacros[i], platform.value.mBeefOptions.mPreprocessorMacros[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mBeefOptions.mDistinctBuildOptions.Count; i++)
+						{
+							ResolveString(unresolvedOptions.mBeefOptions.mDistinctBuildOptions[i].mFilter, platform.value.mBeefOptions.mDistinctBuildOptions[i].mFilter);
+							ResolveString(unresolvedOptions.mBeefOptions.mDistinctBuildOptions[i].mReflectMethodFilter, platform.value.mBeefOptions.mDistinctBuildOptions[i].mReflectMethodFilter);
+						}
+
+						ResolveString(unresolvedOptions.mCOptions.mOtherCFlags, platform.value.mCOptions.mOtherCFlags);
+						ResolveString(unresolvedOptions.mCOptions.mOtherCPPFlags, platform.value.mCOptions.mOtherCPPFlags);
+						
+						for (int32 i = 0; i < unresolvedOptions.mCOptions.mIncludePaths.Count; i++)
+							ResolveString(unresolvedOptions.mCOptions.mIncludePaths[i], platform.value.mCOptions.mIncludePaths[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mCOptions.mPreprocessorMacros.Count; i++)
+							ResolveString(unresolvedOptions.mCOptions.mPreprocessorMacros[i], platform.value.mCOptions.mPreprocessorMacros[i]);
+
+						ResolveString(unresolvedOptions.mCOptions.mAddressSanitizer, platform.value.mCOptions.mAddressSanitizer);
+
+						for (int32 i = 0; i < unresolvedOptions.mCOptions.mSpecificWarningsAsErrors.Count; i++)
+							ResolveString(unresolvedOptions.mCOptions.mSpecificWarningsAsErrors[i], platform.value.mCOptions.mSpecificWarningsAsErrors[i]);
+
+						for (int32 i = 0; i < unresolvedOptions.mCOptions.mDisableSpecificWarnings.Count; i++)
+							ResolveString(unresolvedOptions.mCOptions.mDisableSpecificWarnings[i], platform.value.mCOptions.mDisableSpecificWarnings[i]);
+
+						ResolveString(unresolvedOptions.mDebugOptions.mCommand, platform.value.mDebugOptions.mCommand);
+						ResolveString(unresolvedOptions.mDebugOptions.mCommandArguments, platform.value.mDebugOptions.mCommandArguments);
+						ResolveString(unresolvedOptions.mDebugOptions.mWorkingDirectory, platform.value.mDebugOptions.mWorkingDirectory);
+
+						for (int32 i = 0; i < unresolvedOptions.mDebugOptions.mEnvironmentVars.Count; i++)
+							ResolveString(unresolvedOptions.mDebugOptions.mEnvironmentVars[i], platform.value.mDebugOptions.mEnvironmentVars[i]);
+					}
+
+					unresolvedProject.mConfigs[new String(config.key)] = unresolvedConfig;
+				}
+			}
+
+			if (project.mGeneralOptions != null)
+			{
+				unresolvedProject.mGeneralOptions.mProjectNameDecl.Set(project.mGeneralOptions.mProjectNameDecl);
+				ResolveString(unresolvedProject.mGeneralOptions.mProjectNameDecl, project.mGeneralOptions.mProjectNameDecl);
+
+				unresolvedProject.mGeneralOptions.mVersion.mVersion.Set(project.mGeneralOptions.mVersion.mVersion);
+				ResolveString(unresolvedProject.mGeneralOptions.mVersion.mVersion, project.mGeneralOptions.mVersion.mVersion);
+
+				unresolvedProject.mGeneralOptions.mAliases.Clear();
+				for (String alias in project.mGeneralOptions.mAliases)
+				{
+					String unresolvedAlias = new String(alias);
+					unresolvedProject.mGeneralOptions.mAliases.Add(unresolvedAlias);
+					ResolveString(unresolvedAlias, alias);
+				}
+			}
+
+			if (project.mBeefGlobalOptions != null)
+			{
+				unresolvedProject.mBeefGlobalOptions.mStartupObject.Set(project.mBeefGlobalOptions.mStartupObject);
+				ResolveString(unresolvedProject.mBeefGlobalOptions.mStartupObject, project.mBeefGlobalOptions.mStartupObject);
+
+				unresolvedProject.mBeefGlobalOptions.mDefaultNamespace.Set(project.mBeefGlobalOptions.mDefaultNamespace);
+				ResolveString(unresolvedProject.mBeefGlobalOptions.mDefaultNamespace, project.mBeefGlobalOptions.mDefaultNamespace);
+
+				unresolvedProject.mBeefGlobalOptions.mPreprocessorMacros.Clear();
+				for (String macro in project.mBeefGlobalOptions.mPreprocessorMacros)
+				{
+					String unresolvedMacro = new String(macro);
+					unresolvedProject.mBeefGlobalOptions.mPreprocessorMacros.Add(unresolvedMacro);
+					ResolveString(unresolvedMacro, macro);
+				}
+
+				unresolvedProject.mBeefGlobalOptions.mDistinctBuildOptions.Clear();
+				for (DistinctBuildOptions options in project.mBeefGlobalOptions.mDistinctBuildOptions)
+				{
+					DistinctBuildOptions unresolvedOptions = new DistinctBuildOptions();
+
+					unresolvedOptions.mFilter.Set(options.mFilter);
+					unresolvedOptions.mReflectMethodFilter.Set(options.mReflectMethodFilter);
+					unresolvedProject.mBeefGlobalOptions.mDistinctBuildOptions.Add(unresolvedOptions);
+
+					ResolveString(unresolvedOptions.mFilter, options.mFilter);
+					ResolveString(unresolvedOptions.mReflectMethodFilter, options.mReflectMethodFilter);
+				}
+			}
+
+			if (project.mWindowsOptions != null)
+			{
+				unresolvedProject.mWindowsOptions.mIconFile.Set(project.mWindowsOptions.mIconFile);
+				unresolvedProject.mWindowsOptions.mManifestFile.Set(project.mWindowsOptions.mManifestFile);
+				unresolvedProject.mWindowsOptions.mDescription.Set(project.mWindowsOptions.mDescription);
+				unresolvedProject.mWindowsOptions.mComments.Set(project.mWindowsOptions.mComments);
+				unresolvedProject.mWindowsOptions.mCompany.Set(project.mWindowsOptions.mCompany);
+				unresolvedProject.mWindowsOptions.mProduct.Set(project.mWindowsOptions.mProduct);
+				unresolvedProject.mWindowsOptions.mCopyright.Set(project.mWindowsOptions.mCopyright);
+				unresolvedProject.mWindowsOptions.mFileVersion.Set(project.mWindowsOptions.mFileVersion);
+				unresolvedProject.mWindowsOptions.mProductVersion.Set(project.mWindowsOptions.mProductVersion);
+
+				ResolveString(unresolvedProject.mWindowsOptions.mIconFile, project.mWindowsOptions.mIconFile);
+				ResolveString(unresolvedProject.mWindowsOptions.mManifestFile, project.mWindowsOptions.mManifestFile);
+				ResolveString(unresolvedProject.mWindowsOptions.mDescription, project.mWindowsOptions.mDescription);
+				ResolveString(unresolvedProject.mWindowsOptions.mComments, project.mWindowsOptions.mComments);
+				ResolveString(unresolvedProject.mWindowsOptions.mCompany, project.mWindowsOptions.mCompany);
+				ResolveString(unresolvedProject.mWindowsOptions.mProduct, project.mWindowsOptions.mProduct);
+				ResolveString(unresolvedProject.mWindowsOptions.mCopyright, project.mWindowsOptions.mCopyright);
+				ResolveString(unresolvedProject.mWindowsOptions.mFileVersion, project.mWindowsOptions.mFileVersion);
+				ResolveString(unresolvedProject.mWindowsOptions.mProductVersion, project.mWindowsOptions.mProductVersion);
+			}
+
+			if (project.mLinuxOptions != null)
+			{
+				unresolvedProject.mLinuxOptions.mOptions.Set(project.mLinuxOptions.mOptions);
+				ResolveString(unresolvedProject.mLinuxOptions.mOptions, project.mLinuxOptions.mOptions);
+			}
+
+			if (project.mDependencies != null)
+			{
+				unresolvedProject.mDependencies.Clear();
+				for (Project.Dependency dependency in project.mDependencies)
+				{
+					Project.Dependency unresolvedDependency = new Project.Dependency();
+
+					unresolvedDependency.mVerSpec = dependency.mVerSpec.Duplicate();
+
+					if (dependency.mProjectName != null)
+					{
+						unresolvedDependency.mProjectName = new String();
+						unresolvedDependency.mProjectName.Set(dependency.mProjectName);
+						ResolveString(unresolvedDependency.mProjectName, dependency.mProjectName);
+					}
+
+					unresolvedProject.mDependencies.Add(unresolvedDependency);
+				}
+			}
+		}
+
+		static public void UnresolveProjectProperties(Project project)
+		{
+			if (project == null)
+				return;
+
+			if (!mProjects.ContainsKey(project))
+				return;
+
+			Project unresolvedProject = mProjects[project];
+
+			// Unpack unresolved strings into the project.
+			if (project.mNamespace != null)
+				project.mNamespace.Set(unresolvedProject.mNamespace);
+
+			if (project.mProjectDir != null)
+				project.mProjectDir.Set(unresolvedProject.mProjectDir);
+
+			if (project.mProjectName != null)
+				project.mProjectName.Set(unresolvedProject.mProjectName);
+
+			if (project.mProjectPath != null)
+				project.mProjectPath.Set(unresolvedProject.mProjectPath);
+
+			if (project.mManagedInfo != null)
+			{
+				project.mManagedInfo.mVersion.mVersion.Set(unresolvedProject.mManagedInfo.mVersion.mVersion);
+				project.mManagedInfo.mInfo.Set(unresolvedProject.mManagedInfo.mInfo);
+			}
+
+			if (project.mConfigs != null)
+			{
+				for (var config in project.mConfigs)
+				{
+					Project.Config unresolvedConfig = null;
+
+					for (var c in unresolvedProject.mConfigs)
+					{
+						if (config.key.Equals(c.key))
+						{
+							unresolvedConfig = c.value;
+							break;
+						}
+					}
+
+					if (unresolvedConfig == null)
+						continue;
+
+					for (var platform in config.value.mPlatforms)
+					{
+						Project.Options unresolvedOptions = null;
+
+						for (var p in unresolvedConfig.mPlatforms)
+						{
+							if (platform.key.Equals(p.key))
+							{
+								unresolvedOptions = p.value;
+								break;
+							}
+						}
+
+						if (unresolvedOptions == null)
+							continue;
+
+						platform.value.mBuildOptions.mTargetDirectory.Set(unresolvedOptions.mBuildOptions.mTargetDirectory);
+						platform.value.mBuildOptions.mTargetName.Set(unresolvedOptions.mBuildOptions.mTargetName);
+						platform.value.mBuildOptions.mOtherLinkFlags.Set(unresolvedOptions.mBuildOptions.mOtherLinkFlags);
+
+						for (int32 i = 0; i < platform.value.mBuildOptions.mLibPaths.Count; i++)
+							platform.value.mBuildOptions.mLibPaths[i].Set(unresolvedOptions.mBuildOptions.mLibPaths[i]);
+
+						for (int32 i = 0; i < platform.value.mBuildOptions.mLinkDependencies.Count; i++)
+							platform.value.mBuildOptions.mLinkDependencies[i].Set(unresolvedOptions.mBuildOptions.mLinkDependencies[i]);
+
+						for (int32 i = 0; i < platform.value.mBuildOptions.mPreBuildCmds.Count; i++)
+							platform.value.mBuildOptions.mPreBuildCmds[i].Set(unresolvedOptions.mBuildOptions.mPreBuildCmds[i]);
+
+						for (int32 i = 0; i < platform.value.mBuildOptions.mPostBuildCmds.Count; i++)
+							platform.value.mBuildOptions.mPostBuildCmds[i].Set(unresolvedOptions.mBuildOptions.mPostBuildCmds[i]);
+
+						for (int32 i = 0; i < platform.value.mBuildOptions.mCleanCmds.Count; i++)
+							platform.value.mBuildOptions.mCleanCmds[i].Set(unresolvedOptions.mBuildOptions.mCleanCmds[i]);
+
+						for (int32 i = 0; i < platform.value.mBeefOptions.mPreprocessorMacros.Count; i++)
+							platform.value.mBeefOptions.mPreprocessorMacros[i].Set(unresolvedOptions.mBeefOptions.mPreprocessorMacros[i]);
+
+						for (int32 i = 0; i < platform.value.mBeefOptions.mDistinctBuildOptions.Count; i++)
+						{
+							platform.value.mBeefOptions.mDistinctBuildOptions[i].mFilter.Set(unresolvedOptions.mBeefOptions.mDistinctBuildOptions[i].mFilter);
+							platform.value.mBeefOptions.mDistinctBuildOptions[i].mReflectMethodFilter.Set(unresolvedOptions.mBeefOptions.mDistinctBuildOptions[i].mReflectMethodFilter);
+						}
+
+						platform.value.mCOptions.mOtherCFlags.Set(unresolvedOptions.mCOptions.mOtherCFlags);
+						platform.value.mCOptions.mOtherCPPFlags.Set(unresolvedOptions.mCOptions.mOtherCPPFlags);
+
+						for (int32 i = 0; i < platform.value.mCOptions.mIncludePaths.Count; i++)
+							platform.value.mCOptions.mIncludePaths[i].Set(unresolvedOptions.mCOptions.mIncludePaths[i]);
+
+						for (int32 i = 0; i < platform.value.mCOptions.mPreprocessorMacros.Count; i++)
+							platform.value.mCOptions.mPreprocessorMacros[i].Set(unresolvedOptions.mCOptions.mPreprocessorMacros[i]);
+						
+						platform.value.mCOptions.mAddressSanitizer.Set(unresolvedOptions.mCOptions.mAddressSanitizer);
+
+						for (int32 i = 0; i < platform.value.mCOptions.mSpecificWarningsAsErrors.Count; i++)
+							platform.value.mCOptions.mSpecificWarningsAsErrors[i].Set(unresolvedOptions.mCOptions.mSpecificWarningsAsErrors[i]);
+
+						for (int32 i = 0; i < platform.value.mCOptions.mDisableSpecificWarnings.Count; i++)
+							platform.value.mCOptions.mDisableSpecificWarnings[i].Set(unresolvedOptions.mCOptions.mDisableSpecificWarnings[i]);
+
+						platform.value.mDebugOptions.mCommand.Set(unresolvedOptions.mDebugOptions.mCommand);
+						platform.value.mDebugOptions.mCommandArguments.Set(unresolvedOptions.mDebugOptions.mCommandArguments);
+						platform.value.mDebugOptions.mWorkingDirectory.Set(unresolvedOptions.mDebugOptions.mWorkingDirectory);
+
+						for (int32 i = 0; i < platform.value.mDebugOptions.mEnvironmentVars.Count; i++)
+							platform.value.mDebugOptions.mEnvironmentVars[i].Set(unresolvedOptions.mDebugOptions.mEnvironmentVars[i]);
+					}
+				}
+			}
+
+			if (project.mGeneralOptions != null)
+			{
+				project.mGeneralOptions.mProjectNameDecl.Set(unresolvedProject.mGeneralOptions.mProjectNameDecl);
+				project.mGeneralOptions.mVersion.mVersion.Set(unresolvedProject.mGeneralOptions.mVersion.mVersion);
+
+				for (int32 i = 0; i < project.mGeneralOptions.mAliases.Count; i++)
+					project.mGeneralOptions.mAliases[i].Set(unresolvedProject.mGeneralOptions.mAliases[i]);
+			}
+
+			if (project.mBeefGlobalOptions != null)
+			{
+				project.mBeefGlobalOptions.mStartupObject.Set(unresolvedProject.mBeefGlobalOptions.mStartupObject);
+				project.mBeefGlobalOptions.mDefaultNamespace.Set(unresolvedProject.mBeefGlobalOptions.mDefaultNamespace);
+
+				for (int32 i = 0; i < project.mBeefGlobalOptions.mPreprocessorMacros.Count; i++)
+					project.mBeefGlobalOptions.mPreprocessorMacros[i].Set(unresolvedProject.mBeefGlobalOptions.mPreprocessorMacros[i]);
+
+				for (int32 i = 0; i < project.mBeefGlobalOptions.mDistinctBuildOptions.Count; i++)
+				{
+					project.mBeefGlobalOptions.mDistinctBuildOptions[i].mFilter.Set(unresolvedProject.mBeefGlobalOptions.mDistinctBuildOptions[i].mFilter);
+					project.mBeefGlobalOptions.mDistinctBuildOptions[i].mReflectMethodFilter.Set(unresolvedProject.mBeefGlobalOptions.mDistinctBuildOptions[i].mReflectMethodFilter);
+				}
+			}
+
+			if (project.mWindowsOptions != null)
+			{
+				project.mWindowsOptions.mIconFile.Set(unresolvedProject.mWindowsOptions.mIconFile);
+				project.mWindowsOptions.mManifestFile.Set(unresolvedProject.mWindowsOptions.mManifestFile);
+				project.mWindowsOptions.mDescription.Set(unresolvedProject.mWindowsOptions.mDescription);
+				project.mWindowsOptions.mComments.Set(unresolvedProject.mWindowsOptions.mComments);
+				project.mWindowsOptions.mCompany.Set(unresolvedProject.mWindowsOptions.mCompany);
+				project.mWindowsOptions.mProduct.Set(unresolvedProject.mWindowsOptions.mProduct);
+				project.mWindowsOptions.mCopyright.Set(unresolvedProject.mWindowsOptions.mCopyright);
+				project.mWindowsOptions.mFileVersion.Set(unresolvedProject.mWindowsOptions.mFileVersion);
+				project.mWindowsOptions.mProductVersion.Set(unresolvedProject.mWindowsOptions.mProductVersion);
+			}
+
+			if (project.mLinuxOptions != null)
+				project.mLinuxOptions.mOptions.Set(unresolvedProject.mLinuxOptions.mOptions);
+
+			if (project.mDependencies != null)
+			{
+				for (int32 i = 0; i < project.mDependencies.Count; i++)
+				{
+					if (project.mDependencies[i].mProjectName != null)
+						project.mDependencies[i].mProjectName.Set(unresolvedProject.mDependencies[i].mProjectName);
+				}
+			}
+
+			// Clean up unresolved project.
+			delete mProjects[project];
+			mProjects.Remove(project);
+		}
+	}
+}

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -11062,7 +11062,9 @@ namespace IDE
 			String errorString = scope String();
 			if (!DoResolveConfigString(platformName, workspaceOptions, project, options, configString, errorString, outResult))
 			{
-				OutputErrorLine("Invalid macro in {0}: {1}", errorContext, errorString);
+				if (!CustomBuildProperties.Contains(errorString))
+					OutputErrorLine("Invalid macro in {0}: {1}", errorContext, errorString);
+
 				return false;
 			}
 			return true;

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -3241,6 +3241,27 @@ namespace IDE
 		public Result<Project, ProjectAddError> AddProject(StringView projectName, VerSpec verSpec)
 		{
 			VerSpec useVerSpec = verSpec;
+
+			switch (useVerSpec)
+			{
+			case .None:
+
+			case .SemVer(let ver):
+				String unresolvedVersion = scope String(ver.mVersion);
+				CustomBuildProperties.ResolveString(unresolvedVersion, ver.mVersion);
+
+			case .Path(let path):
+				String unresolvedPath = scope String(path);
+				CustomBuildProperties.ResolveString(unresolvedPath, path);
+
+			case .Git(let url, let ver):
+				String unresolvedUrl = scope String(url);
+				CustomBuildProperties.ResolveString(unresolvedUrl, url);
+
+				String unresolvedVersion = scope String(ver.mVersion);
+				CustomBuildProperties.ResolveString(unresolvedVersion, ver.mVersion);
+			}
+
 			String verConfigDir = mWorkspace.mDir;
 
 			if (let project = mWorkspace.FindProject(projectName))

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -10942,6 +10942,13 @@ namespace IDE
 									}
 								case "BeefPath":
 									newString = gApp.mInstallDir;
+								default:
+									// Check if any custom properties match the string.
+									if (CustomBuildProperties.Contains(replaceStr))
+									{
+										newString = scope:ReplaceBlock String();
+										newString.Append(CustomBuildProperties.Get(replaceStr));
+									}
 								}
 							}
 
@@ -11062,9 +11069,7 @@ namespace IDE
 			String errorString = scope String();
 			if (!DoResolveConfigString(platformName, workspaceOptions, project, options, configString, errorString, outResult))
 			{
-				if (!CustomBuildProperties.Contains(errorString))
-					OutputErrorLine("Invalid macro in {0}: {1}", errorContext, errorString);
-
+				OutputErrorLine("Invalid macro in {0}: {1}", errorContext, errorString);
 				return false;
 			}
 			return true;

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -987,6 +987,7 @@ namespace IDE
 			mWorkspace.mName = new String();
 			Path.GetFileName(mWorkspace.mDir, mWorkspace.mName);
 
+			CustomBuildProperties.Load();
 			LoadWorkspace(.OpenOrNew);
 			FinishShowingNewWorkspace();
 		}
@@ -2258,18 +2259,6 @@ namespace IDE
 			outResult.Append(mInstallDir, "/DefaultLayout.toml");
 		}
 
-		void GetPropertiesFileName(String outResult)
-		{
-			String workspaceDir = scope String();
-
-			if (mWorkspace.mDir == null)
-				Directory.GetCurrentDirectory(workspaceDir);
-			else
-				workspaceDir = mWorkspace.mDir;
-
-			outResult.Append(workspaceDir, "/BeefProperties.toml");
-		}
-
 		bool GetWorkspaceFileName(String outResult)
 		{
 			if (mWorkspace.mDir == null)
@@ -2973,8 +2962,6 @@ namespace IDE
 		{
 			scope AutoBeefPerf("IDEApp.LoadWorkspace");
 
-			CustomBuildProperties.Load();
-
 			AddRecentFile(.OpenedWorkspace, mWorkspace.mDir);
 
 			StructuredData data = null;
@@ -3149,15 +3136,6 @@ namespace IDE
 							LoadFailed();
 							continue;
 						}
-						else if (projSpec.mVerSpec case .Path(let projPath))
-						{
-							String resolvedProjPath = scope String();
-							if (gApp.ResolveConfigString(null, null, null, null, projPath, "custom properties", resolvedProjPath))
-							{
-								projPath.Clear();
-								projPath.Append(resolvedProjPath);
-							}
-						}
 
 						switch (AddProject(projectName, projSpec.mVerSpec))
 						{
@@ -3207,6 +3185,7 @@ namespace IDE
 			CloseWorkspace();
 			mWorkspace.mDir = new String(workspaceDir);
 			mWorkspace.mName = new String(workspaceName);
+			CustomBuildProperties.Load();
 			LoadWorkspace(.Open);
 			FinishShowingNewWorkspace();
 		}

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -229,6 +229,7 @@ namespace IDE
 		public HashSet<String> mWantUpdateVersionLocks ~ DeleteContainerAndItems!(_);
 		public Settings mSettings = new Settings() ~ delete _;
 		public Workspace mWorkspace = new Workspace() ~ delete _;
+		public Dictionary<String, String> mCustomProperties = new .() ~ DeleteDictionaryAndValues!(_);
 		public FileWatcher mFileWatcher = new FileWatcher() ~ delete _;
 #if !CLI
 		public FileRecovery mFileRecovery = new FileRecovery() ~ delete _;
@@ -894,6 +895,8 @@ namespace IDE
 				mExecutionPaused = false;
 			}
 
+			ClearProperties();
+
 			base.Shutdown();
 		}
 
@@ -987,6 +990,7 @@ namespace IDE
 			mWorkspace.mName = new String();
 			Path.GetFileName(mWorkspace.mDir, mWorkspace.mName);
 
+			LoadProperties(true);
 			LoadWorkspace(.OpenOrNew);
 			FinishShowingNewWorkspace();
 		}
@@ -2258,6 +2262,23 @@ namespace IDE
 			outResult.Append(mInstallDir, "/DefaultLayout.toml");
 		}
 
+		void GetPropertiesFileName(String outResult)
+		{
+			String workspaceDir = scope String();
+
+			if (mWorkspace.mDir == null)
+			{
+				Directory.GetCurrentDirectory(workspaceDir);
+			}
+			else
+			{
+				workspaceDir = mWorkspace.mDir;
+			}
+
+			outResult.Append(workspaceDir, "/BeefProperties.toml");
+			IDEUtils.FixFilePath(outResult);
+		}
+
 		bool GetWorkspaceFileName(String outResult)
 		{
 			if (mWorkspace.mDir == null)
@@ -2957,6 +2978,65 @@ namespace IDE
 			FlushDeferredLoadProjects();
 		}
 
+		public void ClearProperties()
+		{
+			for (var entry in mCustomProperties)
+			{
+				delete entry.key;
+				delete entry.value;
+			}
+
+			mCustomProperties.Clear();
+		}
+
+		public void LoadProperties(bool clear = false)
+		{
+			const char8* PROPERTIES_STR = "Properties";
+
+			if (clear)
+			{
+				ClearProperties();
+			}
+
+			String propertiesFileName = scope String();
+			GetPropertiesFileName(propertiesFileName);
+
+			if (!File.Exists(propertiesFileName))
+			{
+				return;
+			}
+
+			StructuredData data = scope StructuredData();
+			if (StructuredLoad(data, propertiesFileName) case .Err(let err))
+			{
+				OutputErrorLine("Failed to load properties '{0}'", propertiesFileName);
+				LoadFailed();
+				return;
+			}
+
+			if (!data.Contains(PROPERTIES_STR))
+			{
+				return;
+			}
+
+			for (var propertyName in data.Enumerate(PROPERTIES_STR))
+			{
+				String propertyKey = new String();
+				propertyName.ToString(propertyKey);
+
+				if (mCustomProperties.ContainsKey(propertyKey))
+				{
+					delete propertyKey;
+					continue;
+				}
+
+				String propertyValue = new String();
+				data.GetCurString(propertyValue);
+
+				mCustomProperties.Add(propertyKey, propertyValue);
+			}
+		}
+
 		protected void LoadWorkspace(BeefVerb verb)
 		{
 			scope AutoBeefPerf("IDEApp.LoadWorkspace");
@@ -3135,6 +3215,15 @@ namespace IDE
 							LoadFailed();
 							continue;
 						}
+						else if (projSpec.mVerSpec case .Path(let projPath))
+						{
+							String resolvedProjPath = scope String();
+							if (gApp.ResolveConfigString(null, null, null, null, projPath, "custom properties", resolvedProjPath))
+							{
+								projPath.Clear();
+								projPath.Append(resolvedProjPath);
+							}
+						}
 
 						switch (AddProject(projectName, projSpec.mVerSpec))
 						{
@@ -3184,6 +3273,7 @@ namespace IDE
 			CloseWorkspace();
 			mWorkspace.mDir = new String(workspaceDir);
 			mWorkspace.mName = new String(workspaceName);
+			LoadProperties(true);
 			LoadWorkspace(.Open);
 			FinishShowingNewWorkspace();
 		}
@@ -10920,6 +11010,12 @@ namespace IDE
 								case "BeefPath":
 									newString = gApp.mInstallDir;
 								default:
+									// Check if any custom properties match the string.
+									if (mCustomProperties.ContainsKey(replaceStr))
+									{
+										newString = scope:ReplaceBlock String();
+										newString.Append(mCustomProperties[replaceStr]);
+									}
 								}
 							}
 

--- a/IDE/src/IDEApp.bf
+++ b/IDE/src/IDEApp.bf
@@ -12831,12 +12831,14 @@ namespace IDE
 			{
 				mWorkspace.mName = new String();
 				Path.GetFileName(mWorkspace.mDir, mWorkspace.mName);
+				CustomBuildProperties.Load();
 				LoadWorkspace(mVerb);
 			}
 			else if (mWorkspace.IsSingleFileWorkspace)
 			{
 				mWorkspace.mName = new String();
 				Path.GetFileNameWithoutExtension(mWorkspace.mCompositeFile.mFilePath, mWorkspace.mName);
+				CustomBuildProperties.Load();
 				LoadWorkspace(mVerb);
 			}
 

--- a/IDE/src/Project.bf
+++ b/IDE/src/Project.bf
@@ -1041,11 +1041,6 @@ namespace IDE
 				data.GetString("FileVersion", mFileVersion);
 				data.GetString("ProductVersion", mProductVersion);
 				String resolvedProductVersion = scope String();
-				if (gApp.ResolveConfigString(null, null, null, null, mProductVersion, "custom properties", resolvedProductVersion))
-				{
-					mProductVersion.Clear();
-					mProductVersion.Append(resolvedProductVersion);
-				}
 			}
 
 			public void Serialize(StructuredData data)

--- a/IDE/src/Project.bf
+++ b/IDE/src/Project.bf
@@ -1040,6 +1040,12 @@ namespace IDE
 				data.GetString("Copyright", mCopyright);
 				data.GetString("FileVersion", mFileVersion);
 				data.GetString("ProductVersion", mProductVersion);
+				String resolvedProductVersion = scope String();
+				if (gApp.ResolveConfigString(null, null, null, null, mProductVersion, "custom properties", resolvedProductVersion))
+				{
+					mProductVersion.Clear();
+					mProductVersion.Append(resolvedProductVersion);
+				}
 			}
 
 			public void Serialize(StructuredData data)

--- a/IDE/src/Project.bf
+++ b/IDE/src/Project.bf
@@ -1040,7 +1040,6 @@ namespace IDE
 				data.GetString("Copyright", mCopyright);
 				data.GetString("FileVersion", mFileVersion);
 				data.GetString("ProductVersion", mProductVersion);
-				String resolvedProductVersion = scope String();
 			}
 
 			public void Serialize(StructuredData data)

--- a/IDE/src/ui/NewProjectDialog.bf
+++ b/IDE/src/ui/NewProjectDialog.bf
@@ -143,7 +143,6 @@ namespace IDE.ui
 				app.mWorkspace.mDir = new String(projDirectory);
 				app.mWorkspace.mName = new String(projName);
 
-				app.LoadProperties(true);
 				app.[Friend]LoadWorkspace(.OpenOrNew);
 				app.[Friend]FinishShowingNewWorkspace(false);
 

--- a/IDE/src/ui/NewProjectDialog.bf
+++ b/IDE/src/ui/NewProjectDialog.bf
@@ -143,6 +143,7 @@ namespace IDE.ui
 				app.mWorkspace.mDir = new String(projDirectory);
 				app.mWorkspace.mName = new String(projName);
 
+				CustomBuildProperties.Load();
 				app.[Friend]LoadWorkspace(.OpenOrNew);
 				app.[Friend]FinishShowingNewWorkspace(false);
 

--- a/IDE/src/ui/NewProjectDialog.bf
+++ b/IDE/src/ui/NewProjectDialog.bf
@@ -142,7 +142,8 @@ namespace IDE.ui
 				DeleteAndNullify!(app.mWorkspace.mDir);
 				app.mWorkspace.mDir = new String(projDirectory);
 				app.mWorkspace.mName = new String(projName);
-				
+
+				app.LoadProperties(true);
 				app.[Friend]LoadWorkspace(.OpenOrNew);
 				app.[Friend]FinishShowingNewWorkspace(false);
 


### PR DESCRIPTION
### Background:

Beef currently allows users to specify certain built-in properties like "$(ProjectName)", "$(WorkspaceDir)", etc. in the BeefProj.toml config file, which are resolved when running the IDE or BeefBuild. This system has a few limitations at the moment:

- Build properties can only be specified in BeefProj.toml and not BeefSpace.toml.
- Build properties can only be used as values for certain items in BeefProj.toml (for example, you can’t use a property as the value for “Platform.Windows.ProductVersion”).
- Users are limited to the current set of built-in properties and can’t define their own.

### Feature Request:

Ideally, we’d like to extend the current build property system to have the following functionality:

- Users can define custom build properties.
- Users can override custom build property values via the command line when running BeefBuild.
- Properties can be specified in both BeefProj.toml and BeefSpace.toml
- Properties can be used in the values for any item in BeefProj.toml and BeefSpace.toml

For additional context, our concrete use cases for this feature are:

- Specifying the Window’s product version for Beef apps via a build property, and being able to override it via the command line when creating new builds.
- The install path for our game engine may differ for each member of our team, so we’d like to avoid hardcoded paths to the engine location in BeefProj.toml and BeefSpace.toml. Instead, we’d like to specify the engine install path as a custom build property so the contents of BeefProj.toml and BeefSpace.toml can remain the same and still work for the whole team.
- Specifying the game engine’s version as a custom build property so that migrating apps to newer engine versions is easier (you just need to update the value of the engine version’s build property).

### Implementation Proposal:

I’ve implemented a proof of concept version of custom build properties in this PR. Custom build properties are specified in a new config file called BeefProperties.toml, which only contains definitions for custom build properties:

BeefProperties.toml
```toml
[Properties]
EngineInstallPath="C:/Program Files/Engine"
EngineVersion="1.2.3.4"
AppVersion="5.6.7.8"
```

I decided to create a new config file so custom build properties can be referenced by both BeefProj.toml and BeefSpace.toml (though I suppose placing them in BeefSpace.toml could work as well). There is also a new “-property” command line option in BeefBuild for specifying or overriding the value of custom build properties.

```
BeefBuild_d.exe -property="AppVersion=9.9.9.9"
```

Most of the implementation is contained in a new file called `CustomBuildProperties.bf` to make updating/reapplying changes easier in case we end up needing to maintain our own Beef distro. Here are the broad strokes of the implementation:

- Properties are loaded from BeefProperties.toml (if available) whenever a workspace is loaded.
- Upon receiving a request to compile a project, any data members of the project that contain custom build properties get resolved (e.g. “$(EngineVersion)” is replaced with “1.2.3.4”). After the project is queued for compilation, the project’s data members get unresolved to the original data (e.g. “1.2.3.4” reverts back to “$(EngineVersion)”). The unresolving process is done so that 1) when viewing project settings in the IDE, the custom build properties still show up as variables, and 2) if the project settings are saved/serialized to BeefProj.toml through the IDE, the custom build properties don’t get replaced with their resolved values.
- For workspaces, this implementation only supports custom build properties in the “Projects” item of BeefSpace.toml at the moment, but I think a similar strategy to how custom build properties are resolved/unresolved in projects could be used.

### Known Issues:

- The resolve/unresolve logic for projects may be a bit overkill/inefficient at the moment. To make sure we can unresolve custom build properties in project data, a deep copy of the project is created before its properties get resolved, and then that copy is used to restore the unresolved properties. As an alternative, I could call ResolveConfigString() before any project/workspace String data member is accessed (as is the current convention in the codebase for built-in properties), but I avoided that route because it would involve a lot more invasive changes and seemed bug-prone.
- I couldn’t seem to find a clean place to resolve/unresolve custom build properties for workspaces, because workspace data seems to be used at various points throughout the IDE lifetime, compared to project data which seems to mainly be used when building the project.
